### PR TITLE
Rewrite ant simulation in JavaScript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,8 @@ This repository originally contains a Unity project implementing an ant simulati
 - Update both sections as you work on the project.
 
 ### Tasks
+- Add interactive controls to tweak colony parameters (pheromone rates, ant count).
+- Optimise pheromone rendering to reduce fill calls on large canvases.
 
 ### Progress
+- Ported the Unity C# simulation behaviour to JavaScript with Canvas-based rendering and pheromone trails.

--- a/js/README.md
+++ b/js/README.md
@@ -1,3 +1,42 @@
 # JavaScript Ant Simulation
 
-This directory will contain the JavaScript port of the ant simulation. The included files are placeholders.
+This directory hosts the browser-based rewrite of the Unity C# ant simulation. The Unity behaviours were translated into plain JavaScript modules that render on an HTML5 canvas.
+
+## Features
+
+- Ant agents wander, search for food, and return to the nest using pheromone trails.
+- Dual pheromone grid (home and food) with diffusion and evaporation.
+- Dynamic food spawning and nest storage tracking.
+- Responsive layout that resizes with the browser window (or press `R` to regenerate the arena).
+
+## Project Structure
+
+- `index.html` – Entry point with canvas and overlay HUD.
+- `styles.css` – Minimal styling for the full-screen canvas and informational HUD.
+- `main.js` – Boots the simulation loop and handles resizing/resetting.
+- `simulation.js` – Manages world state, updates ants, pheromones, nest, and food sources.
+- `entities.js` – Implements ant, food, and nest classes.
+- `pheromoneGrid.js` – Grid-based pheromone storage with evaporation and diffusion.
+- `utils.js` – Vector and math helpers shared across modules.
+
+## Running Locally
+
+No build step is required. Any static file server can host the simulation:
+
+```bash
+# From the repository root
+npx serve js
+```
+
+Then open the reported URL (typically <http://localhost:3000>) in your browser.
+
+Alternatively, open `js/index.html` directly from disk in most modern browsers.
+
+## Controls
+
+- **Resize window / Press `R`** – Reset the simulation arena and respawn food.
+
+## Notes
+
+- The pheromone visualisation uses additive blending: green trails point toward food while blue trails lead home.
+- The simulation intentionally keeps dependencies to zero; everything runs on vanilla ES modules.

--- a/js/entities.js
+++ b/js/entities.js
@@ -1,0 +1,192 @@
+import {
+  TAU,
+  add,
+  angleDifference,
+  clamp,
+  directionFromAngle,
+  distanceSquared,
+  randomRange,
+  wrap,
+  wrapAngle,
+} from './utils.js';
+
+const SEARCHING = 'searching';
+const RETURNING = 'returning';
+
+export class Ant {
+  constructor(position) {
+    this.position = { ...position };
+    this.heading = Math.random() * TAU;
+    this.speed = randomRange(35, 55);
+    this.state = SEARCHING;
+    this.carryingFood = false;
+    this.turnSpeed = Math.PI * 2;
+    this.senseAngle = Math.PI / 4;
+    this.senseDistance = 24;
+    this.depositRate = 220;
+    this.jitterStrength = Math.PI * 0.5;
+  }
+
+  reset(position) {
+    this.position = { ...position };
+    this.state = SEARCHING;
+    this.carryingFood = false;
+    this.heading = Math.random() * TAU;
+    this.speed = randomRange(35, 55);
+  }
+
+  update(dt, world) {
+    const { pheromones, width, height } = world;
+    const depositType = this.state === SEARCHING ? 'home' : 'food';
+    pheromones.addPheromone(this.position.x, this.position.y, depositType, this.depositRate * dt);
+
+    const targetField = this.state === SEARCHING ? 'food' : 'home';
+    const desiredHeading = this._chooseHeading(targetField, world);
+    this._steerTowards(desiredHeading, dt);
+    this._move(dt, width, height);
+    this._interact(world);
+  }
+
+  _chooseHeading(targetField, world) {
+    const senseOffsets = [0, this.senseAngle, -this.senseAngle];
+    let bestHeading = this.heading;
+    let bestValue = -Infinity;
+
+    for (const offset of senseOffsets) {
+      const direction = directionFromAngle(this.heading + offset);
+      const samplePos = add(this.position, {
+        x: direction.x * this.senseDistance,
+        y: direction.y * this.senseDistance,
+      });
+      const value = world.pheromones.sample(samplePos.x, samplePos.y, targetField);
+      const jitter = randomRange(-1, 1) * 5; // slight randomisation
+      const scoredValue = value + jitter;
+      if (scoredValue > bestValue) {
+        bestValue = scoredValue;
+        bestHeading = this.heading + offset;
+      }
+    }
+
+    if (bestValue <= 0) {
+      bestHeading = this.heading + randomRange(-this.senseAngle, this.senseAngle);
+    }
+
+    const wander = randomRange(-this.jitterStrength, this.jitterStrength) * 0.5;
+    return wrapAngle(bestHeading + wander);
+  }
+
+  _steerTowards(targetHeading, dt) {
+    const diff = angleDifference(targetHeading, this.heading);
+    const maxTurn = this.turnSpeed * dt;
+    const turn = clamp(diff, -maxTurn, maxTurn);
+    this.heading = wrapAngle(this.heading + turn);
+  }
+
+  _move(dt, width, height) {
+    const direction = directionFromAngle(this.heading);
+    this.position.x += direction.x * this.speed * dt;
+    this.position.y += direction.y * this.speed * dt;
+
+    this.position.x = wrap(this.position.x, 0, width);
+    this.position.y = wrap(this.position.y, 0, height);
+  }
+
+  _interact(world) {
+    if (this.state === SEARCHING) {
+      const food = world.findFoodNear(this.position);
+      if (food) {
+        this.carryingFood = true;
+        this.state = RETURNING;
+        food.take();
+        const toNest = Math.atan2(world.nest.position.y - this.position.y, world.nest.position.x - this.position.x);
+        this.heading = toNest + randomRange(-Math.PI / 6, Math.PI / 6);
+      }
+    } else if (this.state === RETURNING) {
+      const distanceToNestSq = distanceSquared(this.position, world.nest.position);
+      if (distanceToNestSq <= world.nest.radius * world.nest.radius) {
+        this.carryingFood = false;
+        this.state = SEARCHING;
+        world.nest.deliverFood();
+        this.heading = randomRange(-Math.PI, Math.PI);
+      }
+    }
+  }
+
+  render(context) {
+    context.save();
+    context.translate(this.position.x, this.position.y);
+    context.rotate(this.heading);
+
+    context.beginPath();
+    context.moveTo(6, 0);
+    context.lineTo(-6, 4);
+    context.lineTo(-6, -4);
+    context.closePath();
+    context.fillStyle = this.carryingFood ? '#f0d24d' : '#fefefe';
+    context.fill();
+    context.strokeStyle = 'rgba(0,0,0,0.35)';
+    context.lineWidth = 1;
+    context.stroke();
+
+    context.restore();
+  }
+}
+
+export class FoodSource {
+  constructor(position, amount = 200, radius = 16) {
+    this.position = { ...position };
+    this.amount = amount;
+    this.radius = radius;
+  }
+
+  take() {
+    if (this.amount <= 0) return false;
+    this.amount -= 1;
+    return true;
+  }
+
+  isDepleted() {
+    return this.amount <= 0;
+  }
+
+  render(context) {
+    const alpha = clamp(this.amount / 200, 0.2, 1);
+    context.save();
+    context.translate(this.position.x, this.position.y);
+    const gradient = context.createRadialGradient(0, 0, 2, 0, 0, this.radius);
+    gradient.addColorStop(0, `rgba(0, 180, 120, ${alpha})`);
+    gradient.addColorStop(1, 'rgba(0, 90, 60, 0.1)');
+    context.fillStyle = gradient;
+    context.beginPath();
+    context.arc(0, 0, this.radius, 0, TAU);
+    context.fill();
+    context.restore();
+  }
+}
+
+export class Nest {
+  constructor(position, radius = 22) {
+    this.position = { ...position };
+    this.radius = radius;
+    this.foodStored = 0;
+  }
+
+  deliverFood() {
+    this.foodStored += 1;
+  }
+
+  render(context) {
+    context.save();
+    context.translate(this.position.x, this.position.y);
+    context.fillStyle = '#b07a45';
+    context.beginPath();
+    context.arc(0, 0, this.radius, 0, TAU);
+    context.fill();
+
+    context.fillStyle = '#4b2e16';
+    context.beginPath();
+    context.arc(0, 0, this.radius * 0.45, 0, TAU);
+    context.fill();
+    context.restore();
+  }
+}

--- a/js/index.html
+++ b/js/index.html
@@ -1,11 +1,24 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <title>Ant Simulation JS</title>
-</head>
-<body>
-  <canvas id="canvas"></canvas>
-  <script type="module" src="main.js"></script>
-</body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ant Colony Simulation</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <div class="hud">
+      <h1>Ant Colony Simulation</h1>
+      <p>
+        A browser-based rewrite of the Unity C# project. Watch ants explore,
+        leave pheromone trails, and bring food back to the nest.
+      </p>
+      <ul>
+        <li>Resize the window or press <strong>R</strong> to reset the arena.</li>
+        <li>Blue trails mark the way home, green trails point to food.</li>
+      </ul>
+    </div>
+    <script type="module" src="main.js"></script>
+  </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,2 +1,44 @@
-// Entry point for the JavaScript ant simulation
-console.log('Ant simulation placeholder');
+import { Simulation } from './simulation.js';
+
+const canvas = document.getElementById('canvas');
+canvas.style.display = 'block';
+canvas.style.width = '100vw';
+canvas.style.height = '100vh';
+
+defineCanvasSize();
+const simulation = new Simulation(canvas);
+resizeSimulation();
+
+let lastTime = performance.now();
+function frame(now) {
+  const dt = (now - lastTime) / 1000;
+  lastTime = now;
+  simulation.update(dt);
+  simulation.render();
+  requestAnimationFrame(frame);
+}
+
+requestAnimationFrame((timestamp) => {
+  lastTime = timestamp;
+  frame(timestamp);
+});
+
+window.addEventListener('resize', () => {
+  defineCanvasSize();
+  resizeSimulation();
+});
+
+function defineCanvasSize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+function resizeSimulation() {
+  simulation.resize(canvas.width, canvas.height);
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.key.toLowerCase() === 'r') {
+    resizeSimulation();
+  }
+});

--- a/js/pheromoneGrid.js
+++ b/js/pheromoneGrid.js
@@ -1,0 +1,132 @@
+import { clamp } from './utils.js';
+
+export class PheromoneGrid {
+  constructor(width, height, cellSize = 12) {
+    this.cellSize = cellSize;
+    this.maxIntensity = 300;
+    this.evaporationRate = 0.55; // intensity per second
+    this.diffusionRate = 4.5; // neighbour blending per second
+    this.resize(width, height);
+  }
+
+  resize(width, height) {
+    this.width = width;
+    this.height = height;
+    this.cols = Math.ceil(width / this.cellSize);
+    this.rows = Math.ceil(height / this.cellSize);
+    const cellCount = this.cols * this.rows;
+    this.fields = {
+      food: new Float32Array(cellCount),
+      home: new Float32Array(cellCount),
+    };
+    this._scratch = {
+      food: new Float32Array(cellCount),
+      home: new Float32Array(cellCount),
+    };
+  }
+
+  _indexFromWorld(x, y) {
+    const col = clamp(Math.floor(x / this.cellSize), 0, this.cols - 1);
+    const row = clamp(Math.floor(y / this.cellSize), 0, this.rows - 1);
+    return row * this.cols + col;
+  }
+
+  addPheromone(x, y, type, amount) {
+    const field = this.fields[type];
+    if (!field) return;
+    const index = this._indexFromWorld(x, y);
+    field[index] = clamp(field[index] + amount, 0, this.maxIntensity);
+  }
+
+  sample(x, y, type) {
+    const field = this.fields[type];
+    if (!field) return 0;
+    const index = this._indexFromWorld(x, y);
+    return field[index];
+  }
+
+  update(dt) {
+    this._evaporate(dt);
+    this._diffuse(dt);
+  }
+
+  _evaporate(dt) {
+    const decayFactor = Math.max(0, 1 - this.evaporationRate * dt);
+    for (const key of Object.keys(this.fields)) {
+      const field = this.fields[key];
+      for (let i = 0; i < field.length; i += 1) {
+        field[i] *= decayFactor;
+        if (field[i] < 0.01) field[i] = 0;
+      }
+    }
+  }
+
+  _diffuse(dt) {
+    const blend = clamp(this.diffusionRate * dt, 0, 1);
+    if (blend <= 0) return;
+
+    for (const key of Object.keys(this.fields)) {
+      const field = this.fields[key];
+      const scratch = this._scratch[key];
+      scratch.set(field);
+
+      for (let row = 0; row < this.rows; row += 1) {
+        for (let col = 0; col < this.cols; col += 1) {
+          const index = row * this.cols + col;
+          let total = field[index];
+          let count = 1;
+
+          if (col > 0) {
+            total += scratch[index - 1];
+            count += 1;
+          }
+          if (col < this.cols - 1) {
+            total += scratch[index + 1];
+            count += 1;
+          }
+          if (row > 0) {
+            total += scratch[index - this.cols];
+            count += 1;
+          }
+          if (row < this.rows - 1) {
+            total += scratch[index + this.cols];
+            count += 1;
+          }
+
+          const average = total / count;
+          field[index] = field[index] + (average - field[index]) * blend;
+        }
+      }
+    }
+  }
+
+  render(context) {
+    const alphaScale = 1 / this.maxIntensity;
+    context.save();
+    context.globalCompositeOperation = 'lighter';
+
+    for (const key of Object.keys(this.fields)) {
+      const field = this.fields[key];
+      const color = key === 'food' ? '0, 200, 120' : '70, 140, 255';
+
+      for (let row = 0; row < this.rows; row += 1) {
+        for (let col = 0; col < this.cols; col += 1) {
+          const index = row * this.cols + col;
+          const intensity = field[index];
+          if (intensity <= 0) continue;
+
+          const alpha = clamp(intensity * alphaScale, 0, 0.4);
+          context.fillStyle = `rgba(${color}, ${alpha.toFixed(3)})`;
+          context.fillRect(
+            col * this.cellSize,
+            row * this.cellSize,
+            this.cellSize,
+            this.cellSize,
+          );
+        }
+      }
+    }
+
+    context.restore();
+  }
+}

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -1,0 +1,159 @@
+import { Ant, FoodSource, Nest } from './entities.js';
+import { PheromoneGrid } from './pheromoneGrid.js';
+import { clamp, randomRange } from './utils.js';
+
+export class Simulation {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.context = canvas.getContext('2d');
+    this.width = canvas.width;
+    this.height = canvas.height;
+    this.pheromones = new PheromoneGrid(this.width, this.height);
+    this.nest = new Nest({ x: this.width * 0.5, y: this.height * 0.5 });
+    this.ants = [];
+    this.foodSources = [];
+    this.spawnAnts(120);
+    this.spawnFoodSources();
+    this.maxAnts = 160;
+  }
+
+  resize(width, height) {
+    this.width = width;
+    this.height = height;
+    this.canvas.width = width;
+    this.canvas.height = height;
+    this.pheromones.resize(width, height);
+    this.nest.position = { x: width * 0.5, y: height * 0.5 };
+    this.nest.foodStored = 0;
+    this.foodSources = [];
+    this.spawnFoodSources();
+    for (const ant of this.ants) {
+      const offset = {
+        x: randomRange(-this.nest.radius * 0.5, this.nest.radius * 0.5),
+        y: randomRange(-this.nest.radius * 0.5, this.nest.radius * 0.5),
+      };
+      ant.reset({
+        x: this.nest.position.x + offset.x,
+        y: this.nest.position.y + offset.y,
+      });
+    }
+  }
+
+  spawnAnts(count) {
+    for (let i = 0; i < count; i += 1) {
+      const offsetRadius = randomRange(0, this.nest.radius * 0.6);
+      const angle = randomRange(0, Math.PI * 2);
+      const position = {
+        x: this.nest.position.x + Math.cos(angle) * offsetRadius,
+        y: this.nest.position.y + Math.sin(angle) * offsetRadius,
+      };
+      this.ants.push(new Ant(position));
+    }
+  }
+
+  spawnFoodSources() {
+    const sources = 4;
+    for (let i = 0; i < sources; i += 1) {
+      const margin = 60;
+      const x = randomRange(margin, this.width - margin);
+      const y = randomRange(margin, this.height - margin);
+      const amount = randomRange(160, 320);
+      const radius = clamp(amount / 12, 12, 28);
+      this.foodSources.push(new FoodSource({ x, y }, amount, radius));
+    }
+  }
+
+  update(dt) {
+    const capped = Math.min(dt, 0.12);
+    const steps = Math.max(1, Math.ceil(capped / 0.02));
+    const stepDt = capped / steps;
+
+    for (let step = 0; step < steps; step += 1) {
+      this.pheromones.update(stepDt);
+      for (const ant of this.ants) {
+        ant.update(stepDt, this);
+      }
+    }
+
+    this.foodSources = this.foodSources.filter((source) => !source.isDepleted());
+    if (this.foodSources.length < 3) {
+      this._trySpawnFood();
+    }
+
+    if (this.ants.length < this.maxAnts && this.nest.foodStored > this.ants.length * 0.5) {
+      this.spawnAnts(1);
+    }
+  }
+
+  _trySpawnFood() {
+    const attempts = 5;
+    for (let i = 0; i < attempts; i += 1) {
+      const margin = 80;
+      const x = randomRange(margin, this.width - margin);
+      const y = randomRange(margin, this.height - margin);
+      const amount = randomRange(180, 260);
+      const radius = clamp(amount / 14, 10, 26);
+      const source = new FoodSource({ x, y }, amount, radius);
+      if (this._isLocationFree(source.position, source.radius)) {
+        this.foodSources.push(source);
+        return;
+      }
+    }
+  }
+
+  _isLocationFree(position, radius) {
+    if (Math.hypot(position.x - this.nest.position.x, position.y - this.nest.position.y) < this.nest.radius * 4) {
+      return false;
+    }
+
+    return this.foodSources.every((source) => {
+      const dx = source.position.x - position.x;
+      const dy = source.position.y - position.y;
+      const minDistance = source.radius + radius + 40;
+      return dx * dx + dy * dy > minDistance * minDistance;
+    });
+  }
+
+  findFoodNear(position) {
+    for (const source of this.foodSources) {
+      const dx = source.position.x - position.x;
+      const dy = source.position.y - position.y;
+      if (dx * dx + dy * dy <= source.radius * source.radius && source.amount > 0) {
+        return source;
+      }
+    }
+    return null;
+  }
+
+  render() {
+    const { context } = this;
+    context.fillStyle = '#1c1b1f';
+    context.fillRect(0, 0, this.width, this.height);
+
+    this.pheromones.render(context);
+
+    for (const source of this.foodSources) {
+      source.render(context);
+    }
+
+    this.nest.render(context);
+
+    for (const ant of this.ants) {
+      ant.render(context);
+    }
+
+    this._renderOverlay();
+  }
+
+  _renderOverlay() {
+    const { context } = this;
+    context.save();
+    context.fillStyle = 'rgba(255, 255, 255, 0.85)';
+    context.font = '14px "Fira Sans", "Segoe UI", sans-serif';
+    context.textBaseline = 'top';
+    context.fillText(`Ants: ${this.ants.length}`, 16, 16);
+    context.fillText(`Food stored: ${this.nest.foodStored}`, 16, 34);
+    context.fillText('Tip: Resize the window to reshape the terrain.', 16, 52);
+    context.restore();
+  }
+}

--- a/js/styles.css
+++ b/js/styles.css
@@ -1,0 +1,57 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Fira Sans', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #101014;
+  color: #fefefe;
+  overflow: hidden;
+}
+
+#canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
+.hud {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  max-width: 280px;
+  background: rgba(16, 16, 20, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 16px 20px;
+  backdrop-filter: blur(6px);
+}
+
+.hud h1 {
+  margin: 0 0 8px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.hud p {
+  margin: 0 0 12px;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.hud ul {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.hud li + li {
+  margin-top: 6px;
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,90 @@
+export const TAU = Math.PI * 2;
+
+export function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function wrap(value, min, max) {
+  const range = max - min;
+  if (range === 0) return min;
+  let result = (value - min) % range;
+  if (result < 0) result += range;
+  return result + min;
+}
+
+export function distanceSquared(a, b) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function randomRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+export function angleDifference(target, source) {
+  let diff = target - source;
+  while (diff > Math.PI) diff -= TAU;
+  while (diff < -Math.PI) diff += TAU;
+  return diff;
+}
+
+export function wrapAngle(angle) {
+  while (angle <= -Math.PI) angle += TAU;
+  while (angle > Math.PI) angle -= TAU;
+  return angle;
+}
+
+export function rotateVector(vector, angle) {
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  return {
+    x: vector.x * cos - vector.y * sin,
+    y: vector.x * sin + vector.y * cos,
+  };
+}
+
+export function normalize(vector) {
+  const length = Math.hypot(vector.x, vector.y);
+  if (length === 0) {
+    return { x: 1, y: 0 };
+  }
+  return { x: vector.x / length, y: vector.y / length };
+}
+
+export function scale(vector, scalar) {
+  return { x: vector.x * scalar, y: vector.y * scalar };
+}
+
+export function add(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y };
+}
+
+export function subtract(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y };
+}
+
+export function length(vector) {
+  return Math.hypot(vector.x, vector.y);
+}
+
+export function setLength(vector, newLength) {
+  const current = length(vector);
+  if (current === 0) {
+    return { x: newLength, y: 0 };
+  }
+  const scaleFactor = newLength / current;
+  return { x: vector.x * scaleFactor, y: vector.y * scaleFactor };
+}
+
+export function directionFromAngle(angle) {
+  return { x: Math.cos(angle), y: Math.sin(angle) };
+}
+
+export function angleFromDirection(vector) {
+  return Math.atan2(vector.y, vector.x);
+}


### PR DESCRIPTION
## Summary
- replace the placeholder JavaScript files with a full canvas-based ant colony simulation
- implement ants, pheromone grid, nest, and food source entities along with a simulation loop and responsive layout
- document the new JavaScript architecture and update project progress/tasks

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68deb5fc637083288f6b7dee46ea26dc